### PR TITLE
KATTS-2621 Change method stub syntax, change 'should' syntax to 'expect'...

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Compatibility
 Rhubarb is tested on
 
 * **Ruby 1.9.3** on **Linux 3.0.0**
+* **Ruby 2.0.0** on developer laptops
 
 That is all. It's targetted for RHEL 5.3, which has not that Ruby, so it also requires something like [KSI](https://github.com/ua-eas/ksi) to be installed and working.
 

--- a/features/step_definitions/verification_steps.rb
+++ b/features/step_definitions/verification_steps.rb
@@ -32,13 +32,13 @@ Then /^I should see no logs in the logs directory$/ do
 end
 
 Then /^I should see a log in the "(.*?)" log archive directory$/ do |job_stream|
-  File.directory?(File.join(ENV['BATCH_HOME'], 'logs', job_stream)).should be_true
+  expect(File.directory?(File.join(ENV['BATCH_HOME'], 'logs', job_stream))).to be true
   Dir.glob(File.join(ENV['BATCH_HOME'], 'logs', job_stream, '*.log')).should_not be_empty
 end
 
 Then /^I should see (\d+) logs in the "(.*?)" log archive directory$/ do |count, job_stream|
   count = count.to_i
-  File.directory?(File.join(ENV['BATCH_HOME'], 'logs', job_stream)).should be_true
+  expect(File.directory?(File.join(ENV['BATCH_HOME'], 'logs', job_stream))).to be true
   Dir.glob(File.join(ENV['BATCH_HOME'], 'logs', job_stream, '*.log')).size.should be count
 end
 

--- a/spec/archivist_spec.rb
+++ b/spec/archivist_spec.rb
@@ -8,29 +8,29 @@ describe Rhubarb::Archivist, '.new' do
   end
 
   it 'should abandon ship without $BATCH_HOME' do
-    Rhubarb.stub(:batch_home).and_return(nil)
+    allow(Rhubarb).to receive(:batch_home).and_return(nil)
     expect { Rhubarb::Archivist.new('foo') }.to raise_error(Rhubarb::MissingBatchHomeError)
   end
 
   it 'should abandon ship with an invalid $BATCH_HOME' do
     batch_home = File.join(@live_dir, 'uaf-fake')
-    Rhubarb.stub(:batch_home).and_return(batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(batch_home)
     expect { Rhubarb::Archivist.new('foo') }.to raise_error(Rhubarb::InvalidBatchHomeError)
   end
 
   it 'should abandon ship with an empty $BATCH_HOME directory' do
     batch_home = File.join(@live_dir, 'uaf-tst')
-    Rhubarb.stub(:batch_home).and_return(batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(batch_home)
     expect { Rhubarb::Archivist.new('foo') }.to raise_error(Rhubarb::EmptyBatchHomeError)
   end
 
   it 'should abandon ship with empty arguments' do
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
     expect { Rhubarb::Archivist.new }.to raise_error(ArgumentError)
   end
 
   it 'should initialize successfully with one valid argument' do
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
     expect { Rhubarb::Archivist.new('foo') }.to_not raise_error
   end
 end
@@ -41,7 +41,7 @@ describe Rhubarb::Archivist, '#archive' do
   before(:each) do
     cleanse_live
 
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
     @accept_dir   = ['purap', 'electronicInvoice', 'accept']
     @shipping_dir = ['pdp', 'shipping']
     @pcard_dir    = ['fp', 'procurementCard']
@@ -53,25 +53,25 @@ describe Rhubarb::Archivist, '#archive' do
   end
 
   it 'should log an archive job successfully' do
-    @archivist_01.logger.should_receive(:info).at_least(3).times
+    expect(@archivist_01.logger).to receive(:info).at_least(3).times
     @archivist_01.archive!
   end
 
   it 'should remove from staging/ successfully' do
     @archivist_01.archive!
-    Dir.glob(File.join(@staging_dir, *@accept_dir) + '/*').should be_empty
+    expect(Dir.glob(File.join(@staging_dir, *@accept_dir) + '/*')).to be_empty
   end
 
   it 'should add to archive/ successfully' do
     @archivist_01.archive!
-    Dir.glob(File.join(@archive_dir, *@accept_dir) + '/*').should_not be_empty
+    expect(Dir.glob(File.join(@archive_dir, *@accept_dir) + '/*')).not_to be_empty
   end
 
   it 'should archive successfully even if the target directory doesn\'t exist' do
     @archivist_02.archive!
     #@archivist_02.logger.should_receive(:info).at_least(4).times
-    Dir.glob(File.join(@staging_dir, *@shipping_dir) + '/*').should be_empty
-    Dir.glob(File.join(@archive_dir, *@shipping_dir) + '/*').should_not be_empty
+    expect(Dir.glob(File.join(@staging_dir, *@shipping_dir) + '/*')).to be_empty
+    expect(Dir.glob(File.join(@archive_dir, *@shipping_dir) + '/*')).not_to be_empty
   end
 
   it 'should not raise when source directory doesn\'t exist' do

--- a/spec/calendar_spec.rb
+++ b/spec/calendar_spec.rb
@@ -5,7 +5,7 @@ describe Rhubarb::Calendar, "#event_from_log_lines" do
 
   before(:each) do
     cleanse_live
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
 
     @cal = Rhubarb::Calendar.new
     lines = <<LOGLINES
@@ -23,14 +23,14 @@ LOGLINES
   end
 
   it "should create an iCalendar event for a single job execution with a correct summary" do
-    @event.summary.should =~ /processPdpCancelsAndPaidJob/
+    expect(@event.summary).to be =~ /processPdpCancelsAndPaidJob/
   end
 
   it "should create an iCalendar event for a single job execution with a correct dtstart" do
-    @event.dtstart.should == DateTime.new(2012, 10, 25, 6, 50, 06)
+    expect(@event.dtstart).to be == DateTime.new(2012, 10, 25, 6, 50, 06)
   end
 
   it "should create an iCalendar event for a single job execution with a correct dtend" do
-    @event.dtend.should   == DateTime.new(2012, 10, 25, 6, 56, 03)
+    expect(@event.dtend).to be == DateTime.new(2012, 10, 25, 6, 56, 03)
   end
 end

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -8,55 +8,55 @@ describe Rhubarb::Driver, '.new' do
   end
 
   it 'should abandon ship without $BATCH_HOME' do
-    Rhubarb.stub(:batch_home).and_return(nil)
+    allow(Rhubarb).to receive(:batch_home).and_return(nil)
     expect { Rhubarb::Driver.new('foo', 'bar') }.to raise_error(Rhubarb::MissingBatchHomeError)
   end
 
   it 'should abandon ship with an invalid $BATCH_HOME' do
     batch_home = File.join(@live_dir, 'uaf-fake')
-    Rhubarb.stub(:batch_home).and_return(batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(batch_home)
     expect { Rhubarb::Driver.new('foo', 'bar') }.to raise_error(Rhubarb::InvalidBatchHomeError)
   end
 
   it 'should abandon ship with an empty $BATCH_HOME directory' do
     batch_home = File.join(@live_dir, 'uaf-tst')
-    Rhubarb.stub(:batch_home).and_return(batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(batch_home)
     expect { Rhubarb::Driver.new('foo', 'bar') }.to raise_error(Rhubarb::EmptyBatchHomeError)
   end
 
   it 'should abandon ship without a control directory' do
     batch_home = File.join(@live_dir, 'uaf-cfg')
-    Rhubarb.stub(:batch_home).and_return(batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(batch_home)
     expect { Rhubarb::Driver.new('foo', 'bar') }.to raise_error(Rhubarb::MissingControlDirectoryError)
   end
 
   it 'should ERROR log the missing control directory' do
-    Rhubarb.stub(:batch_home).and_return(@cfg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@cfg_batch_home)
     begin
       driver = Rhubarb::Driver.new('einvoice', 'clearCacheJob')
     rescue => e
     end
     lines = File.readlines(File.join(Rhubarb.batch_home, 'logs', "einvoice.log"))
-    lines.last.should match /[0-9:]{8} \(ERROR\) .*control.*/
+    expect(lines.last).to match /[0-9:]{8} \(ERROR\) .*control.*/
   end
 
   it 'should initialize successfully' do
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
     expect { Rhubarb::Driver.new('einvoice', 'clearCacheJob') }.to_not raise_error
   end
 
   it 'should DEBUG log that it was initialized' do
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
     driver = Rhubarb::Driver.new('einvoice', 'clearCacheJob')
     lines = File.readlines(driver.logger.job_stream_file)
-    lines.should include_something_like /[0-9:]{8} \(DEBUG\) .*einvoice.*clearCacheJob/
+    expect(lines).to include_something_like /[0-9:]{8} \(DEBUG\) .*einvoice.*clearCacheJob/
   end
 
   it 'should DEBUG log various instance variables' do
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
     driver = Rhubarb::Driver.new('einvoice', 'clearCacheJob')
     lines = File.readlines(driver.logger.job_stream_file)
-    lines.should include_something_like /[0-9:]{8} \(DEBUG\) .*batch_home/
+    expect(lines).to include_something_like /[0-9:]{8} \(DEBUG\) .*batch_home/
   end
 end
 
@@ -66,26 +66,26 @@ describe Rhubarb::Driver, '#drop_runfile' do
   before(:each) do
     cleanse_live
 
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
     @driver = Rhubarb::Driver.new('einvoice', 'clearCacheJob')
     @control_dir = File.join(@stg_batch_home, 'control')
   end
 
   it 'should raise if the runfile directory is not writable' do
-    Rhubarb.stub(:batch_home).and_return(@trn_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@trn_batch_home)
     @driver = Rhubarb::Driver.new('einvoice', 'clearCacheJob')
     expect { @driver.drop_runfile }.to raise_error(Rhubarb::UnwritableControlDirectoryError)
   end
 
   it 'should ERROR log if the runfile directory is not writable' do
-    Rhubarb.stub(:batch_home).and_return(@trn_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@trn_batch_home)
     @driver = Rhubarb::Driver.new('einvoice', 'clearCacheJob')
     begin
       @driver.drop_runfile
     rescue => error
     end
     lines = File.readlines(@driver.logger.job_stream_file)
-    lines.should include_something_like /[0-9:]{8} \(ERROR\) .*Could not/
+    expect(lines).to include_something_like /[0-9:]{8} \(ERROR\) .*Could not/
   end
 
   it 'should drop a runfile' do
@@ -96,7 +96,7 @@ describe Rhubarb::Driver, '#drop_runfile' do
       expected_runfile_name = @driver.drop_runfile
     end
     latest_runfile = Dir.glob(File.join(@control_dir, '*.run')).sort_by { |runfile| File.mtime(runfile) }.last
-    latest_runfile.should eq expected_runfile_name
+    expect(latest_runfile).to eq expected_runfile_name
   end
 end
 
@@ -106,7 +106,7 @@ describe Rhubarb::Driver, '#wait_for_statusfile' do
   before(:each) do
     cleanse_live
 
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
     @driver = Rhubarb::Driver.new('einvoice', 'clearCacheJob')
     @driver.status_timeout = 10
     @driver.status_sleep = 1
@@ -131,7 +131,7 @@ describe Rhubarb::Driver, '#wait_for_statusfile' do
     end
 
     lines = File.readlines(@driver.logger.job_stream_file)
-    lines.should include_something_like /[0-9:]{8} \(INFO\) .*Waiting for/
+    expect(lines).to include_something_like /[0-9:]{8} \(INFO\) .*Waiting for/
   end
 
   it 'should ERROR log when no status file shows up' do
@@ -141,7 +141,7 @@ describe Rhubarb::Driver, '#wait_for_statusfile' do
     end
 
     lines = File.readlines(@driver.logger.job_stream_file)
-    lines.should include_something_like /[0-9:]{8} \(ERROR\) .*Runfile was never/
+    expect(lines).to include_something_like /[0-9:]{8} \(ERROR\) .*Runfile was never/
   end
 
   it 'should timeout and raise when the runfile doesn\'t leave, even if the status file shows up' do
@@ -152,7 +152,7 @@ describe Rhubarb::Driver, '#wait_for_statusfile' do
   it 'should return the name of the statusfile when the runfile disappears and the statusfile appears _early_' do
     FileUtils.rm @driver.job_runfile
     FileUtils.touch @driver.job_statusfile
-    @driver.wait_for_statusfile.should eq @driver.job_statusfile
+    expect(@driver.wait_for_statusfile).to eq @driver.job_statusfile
   end
 
   it 'should return the name of the statusfile when the runfile disappears and the statusfile appears' do
@@ -167,7 +167,7 @@ describe Rhubarb::Driver, '#wait_for_statusfile' do
     FileUtils.touch @driver.job_statusfile
 
     waiter_return = statusfile_waiter.value
-    waiter_return.should eq @driver.job_statusfile
+    expect(waiter_return).to eq @driver.job_statusfile
   end
 
   it 'should INFO log when the runfile disappears and the statusfile appears' do
@@ -184,7 +184,7 @@ describe Rhubarb::Driver, '#wait_for_statusfile' do
     statusfile_waiter.join
 
     lines = File.readlines(@driver.logger.job_stream_file)
-    lines.should include_something_like /[0-9:]{8} \(INFO\) .*Statusfile found/
+    expect(lines).to include_something_like /[0-9:]{8} \(INFO\) .*Statusfile found/
   end
 end
 
@@ -194,27 +194,27 @@ describe Rhubarb::Driver, '#status_line' do
   before(:each) do
     cleanse_live
 
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
     @driver = Rhubarb::Driver.new('einvoice', 'clearCacheJob')
   end
 
   it 'should return nil if there is no Statusfile' do
-    @driver.status_line.should be nil
+    expect(@driver.status_line).to be nil
   end
 
   it 'should return nil if the Statusfile is empty' do
     FileUtils.touch @driver.job_statusfile
-    @driver.status_line.should be nil
+    expect(@driver.status_line).to be nil
   end
 
   it 'should return the last line if the Statusfile is not empty' do
     File.open(@driver.job_statusfile, 'w') { |handle| handle.write("Line One\nLine 2\nLine Trois") }
-    @driver.status_line.should eq "Line Trois"
+    expect(@driver.status_line).to eq "Line Trois"
   end
 
   it 'should return the last line if the Statusfile is not empty' do
     File.open(@driver.job_statusfile, 'w') { |handle| handle.write("Line One\nLine 2\nLine Trois\n") }
-    @driver.status_line.should eq "Line Trois"
+    expect(@driver.status_line).to eq "Line Trois"
   end
 end
 
@@ -224,23 +224,23 @@ describe Rhubarb::Driver, '#succeeded?' do
   before(:each) do
     cleanse_live
 
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
     @driver = Rhubarb::Driver.new('einvoice', 'clearCacheJob')
   end
 
   it 'should return nil if #status_line returns nil' do
-    @driver.stub(:status_line).and_return(nil)
-    @driver.succeeded?.should be nil
+    allow(@driver).to receive(:status_line).and_return(nil)
+    expect(@driver.succeeded?).to be nil
   end
 
   it 'should return true if #status_line returns "foo bar baz Succeeded bing bang bong"' do
-    @driver.stub(:status_line).and_return("foo bar baz Succeeded bing bang bong")
-    @driver.succeeded?.should be true
+    allow(@driver).to receive(:status_line).and_return("foo bar baz Succeeded bing bang bong")
+    expect(@driver.succeeded?).to be true
   end
 
   it 'should return false if #status_line returns "anything else here"' do
-    @driver.stub(:status_line).and_return("anything else here")
-    @driver.succeeded?.should be false
+    allow(@driver).to receive(:status_line).and_return("anything else here")
+    expect(@driver.succeeded?).to be false
   end
 end
 
@@ -250,15 +250,15 @@ describe Rhubarb::Driver, '#drive' do
   before(:each) do
     cleanse_live
 
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
     @driver = Rhubarb::Driver.new('einvoice', 'clearCacheJob')
   end
 
   it 'should return true if the job succeeded' do
-    @driver.stub(:drop_runfile).and_return(true)
-    @driver.stub(:wait_for_statusfile).and_return(true)
-    @driver.stub(:status_line).and_return('I guess I... Succeeded!')
-    @driver.stub(:succeeded?).and_return(true)
-    @driver.drive.should be true
+    allow(@driver).to receive(:drop_runfile).and_return(true)
+    allow(@driver).to receive(:wait_for_statusfile).and_return(true)
+    allow(@driver).to receive(:status_line).and_return('I guess I... Succeeded!')
+    allow(@driver).to receive(:succeeded?).and_return(true)
+    expect(@driver.drive).to be true
   end
 end

--- a/spec/email_config_spec.rb
+++ b/spec/email_config_spec.rb
@@ -8,7 +8,7 @@ describe Rhubarb::Email, "#parse_config" do
 
   before(:each) do
     cleanse_live
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
 
   end
 
@@ -29,70 +29,70 @@ describe Rhubarb::Email, "#parse_config" do
 
 
   it "should generate JobStream representing the whole job_stream, with a correct name" do
-    @js.name.should == "ARCHIBUSFOO"
+    expect(@js.name).to be == "ARCHIBUSFOO"
   end
 
   it "should generate JobStream representing the whole job_stream, with a correct Output" do
-    @js.outputs['job_not_ok'].should_not be nil
-    @js.outputs['job_ok'].should_not be nil
+    expect(@js.outputs['job_not_ok']).not_to be_nil
+    expect(@js.outputs['job_ok']).not_to be_nil
   end
 
   it "should generate Output with a correct name" do
-    @js.outputs['job_ok'].name.should == "job_ok"
-    @js.outputs['job_not_ok'].name.should == "job_not_ok"
+    expect(@js.outputs['job_ok'].name).to be == "job_ok"
+    expect(@js.outputs['job_not_ok'].name).to be == "job_not_ok"
   end
 
   it "should generate Output with a correct subject" do
-    @js.outputs['job_ok'].subject.should == "DEV - UAF-FOO-DLV-EMAIL - Job Success"
-    @js.outputs['job_not_ok'].subject.should == "DEV - UAF-FOO-DLV-EMAIL - Job Failed"
+    expect(@js.outputs['job_ok'].subject).to be == "DEV - UAF-FOO-DLV-EMAIL - Job Success"
+    expect(@js.outputs['job_not_ok'].subject).to be == "DEV - UAF-FOO-DLV-EMAIL - Job Failed"
   end
 
   it "should generate Output with a correct message" do
 
     expected =  "The job FOO has finished successfully.\n"
-    @js.outputs['job_ok'].text_part.body.to_s.should == "The job FOO has finished successfully.\n"
+    expect(@js.outputs['job_ok'].text_part.body.to_s).to be == "The job FOO has finished successfully.\n"
 
     date = Time.new
     date = date.strftime("%m/%d/%Y")
 
     expected =  "The job FOO has failed on #{date}, \nattached is a log of events,\n"
     expected += "please see KFS logs for further detail.\n"
-    @js.outputs['job_not_ok'].text_part.body.to_s.should == expected
+    expect(@js.outputs['job_not_ok'].text_part.body.to_s).to be == expected
   end
 
   it "should generate Output with correct to entries" do
-    @js.outputs['job_ok']['to'].to_s.should include("katt-automation@list.arizona.edu")
-    @js.outputs['job_ok']['to'].to_s.should include("shaloo@email.arizona.edu")
-    @js.outputs['job_not_ok']['to'].to_s.should include("katt-automation@list.arizona.edu")
-    @js.outputs['job_not_ok']['to'].to_s.should include("shaloo@email.arizona.edu")
+    expect(@js.outputs['job_ok']['to'].to_s).to include("katt-automation@list.arizona.edu")
+    expect(@js.outputs['job_ok']['to'].to_s).to include("shaloo@email.arizona.edu")
+    expect(@js.outputs['job_not_ok']['to'].to_s).to include("katt-automation@list.arizona.edu")
+    expect(@js.outputs['job_not_ok']['to'].to_s).to include("shaloo@email.arizona.edu")
   end
 
   it "should generate an Output with correct attachments globs" do
-    @js.outputs['job_not_ok'].attachments.map(&:filename).should include("foo_1.log")
-    @js.outputs['job_not_ok'].attachments.map(&:filename).should include("foo_2.log")
-    @js.outputs['job_not_ok'].attachments.map(&:filename).should include("foo_3.log")
-    @js.outputs['job_not_ok'].attachments.map(&:filename).should include("foo_4.log")
-    @js.outputs['job_not_ok'].attachments.map(&:filename).should include("bar_1.log")
-    @js.outputs['job_not_ok'].attachments.map(&:filename).should include("bar_2.log")
-    @js.outputs['job_not_ok'].attachments.map(&:filename).should include("bar_3.log")
-    @js.outputs['job_not_ok'].attachments.map(&:filename).should include("bar_4.log")
+    expect(@js.outputs['job_not_ok'].attachments.map(&:filename)).to include("foo_1.log")
+    expect(@js.outputs['job_not_ok'].attachments.map(&:filename)).to include("foo_2.log")
+    expect(@js.outputs['job_not_ok'].attachments.map(&:filename)).to include("foo_3.log")
+    expect(@js.outputs['job_not_ok'].attachments.map(&:filename)).to include("foo_4.log")
+    expect(@js.outputs['job_not_ok'].attachments.map(&:filename)).to include("bar_1.log")
+    expect(@js.outputs['job_not_ok'].attachments.map(&:filename)).to include("bar_2.log")
+    expect(@js.outputs['job_not_ok'].attachments.map(&:filename)).to include("bar_3.log")
+    expect(@js.outputs['job_not_ok'].attachments.map(&:filename)).to include("bar_4.log")
 
-    @js.outputs['job_ok'].attachments.map(&:filename).should include("foo_1.log")
-    @js.outputs['job_ok'].attachments.map(&:filename).should include("foo_2.log")
-    @js.outputs['job_ok'].attachments.map(&:filename).should include("foo_3.log")
-    @js.outputs['job_ok'].attachments.map(&:filename).should include("foo_4.log")
-    @js.outputs['job_ok'].attachments.map(&:filename).should include("bar_1.log")
-    @js.outputs['job_ok'].attachments.map(&:filename).should include("bar_2.log")
-    @js.outputs['job_ok'].attachments.map(&:filename).should include("bar_3.log")
-    @js.outputs['job_ok'].attachments.map(&:filename).should include("bar_4.log")
+    expect(@js.outputs['job_ok'].attachments.map(&:filename)).to include("foo_1.log")
+    expect(@js.outputs['job_ok'].attachments.map(&:filename)).to include("foo_2.log")
+    expect(@js.outputs['job_ok'].attachments.map(&:filename)).to include("foo_3.log")
+    expect(@js.outputs['job_ok'].attachments.map(&:filename)).to include("foo_4.log")
+    expect(@js.outputs['job_ok'].attachments.map(&:filename)).to include("bar_1.log")
+    expect(@js.outputs['job_ok'].attachments.map(&:filename)).to include("bar_2.log")
+    expect(@js.outputs['job_ok'].attachments.map(&:filename)).to include("bar_3.log")
+    expect(@js.outputs['job_ok'].attachments.map(&:filename)).to include("bar_4.log")
     # the helper creates a tracking file for baz_1.log so this should not be included!
-    @js.outputs['job_ok'].attachments.map(&:filename).should_not include("ARCHIBUSFOO_baz_1.log")
-    @js.outputs['job_ok'].attachments.map(&:filename).should include("ARCHIBUSFOO_baz_2.log")
-    @js.outputs['job_ok'].attachments.map(&:filename).should include("ARCHIBUSFOO_baz_3.log")
-    @js.outputs['job_ok'].attachments.map(&:filename).should include("ARCHIBUSFOO_baz_4.log")
+    expect(@js.outputs['job_ok'].attachments.map(&:filename)).not_to include("ARCHIBUSFOO_baz_1.log")
+    expect(@js.outputs['job_ok'].attachments.map(&:filename)).to include("ARCHIBUSFOO_baz_2.log")
+    expect(@js.outputs['job_ok'].attachments.map(&:filename)).to include("ARCHIBUSFOO_baz_3.log")
+    expect(@js.outputs['job_ok'].attachments.map(&:filename)).to include("ARCHIBUSFOO_baz_4.log")
   end
 
   it "should generate multiple Outputs" do
-    @js.outputs.count.should == 2
+    expect(@js.outputs.count).to be == 2
   end
 end

--- a/spec/email_deliver_spec.rb
+++ b/spec/email_deliver_spec.rb
@@ -6,7 +6,7 @@ describe Rhubarb::Email, ".new" do
 
   before(:each) do
     cleanse_live
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
   end
 
   before(:all) do
@@ -41,7 +41,7 @@ describe Rhubarb::Email, ".new" do
   context "not really delivering" do
     before(:each) do
       cleanse_live
-      Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+      allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
 
       @js_from_file.set_delivery_method :test
       @js_w_attachments.set_delivery_method :test
@@ -50,19 +50,19 @@ describe Rhubarb::Email, ".new" do
 
     it "should deliver a basic report for a single output" do
       @js_from_file.deliver 'foo'
-      @js_from_file.should have_sent_email.to("kfsbsa@list.arizona.edu")
+      expect(@js_from_file).to have_sent_email.to("kfsbsa@list.arizona.edu")
     end
 
     it "should deliver a report for all outputs" do
       @js_w_attachments.deliver 'all'
-      @js_w_attachments.should have_sent_email.to("shaloo@email.arizona.edu")
-      @js_w_attachments.should have_sent_email.to("katt-automation@list.arizona.edu")
+      expect(@js_w_attachments).to have_sent_email.to("shaloo@email.arizona.edu")
+      expect(@js_w_attachments).to have_sent_email.to("katt-automation@list.arizona.edu")
     end
 
     it "should deliver a basic report from a config file" do
       @js_from_file.deliver 'foo'
-      @js_from_file.should have_sent_email.to("katt-automation@list.arizona.edu")
-      @js_from_file.should have_sent_email.to("kfsbsa@list.arizona.edu")
+      expect(@js_from_file).to have_sent_email.to("katt-automation@list.arizona.edu")
+      expect(@js_from_file).to have_sent_email.to("kfsbsa@list.arizona.edu")
     end
   end
 end

--- a/spec/log_roll_spec.rb
+++ b/spec/log_roll_spec.rb
@@ -8,24 +8,24 @@ describe Rhubarb::LogRoller, '.new' do
   end
 
   it 'should abandon ship without $BATCH_HOME' do
-    Rhubarb.stub(:batch_home).and_return(nil)
+    allow(Rhubarb).to receive(:batch_home).and_return(nil)
     expect { Rhubarb::LogRoller.new }.to raise_error(Rhubarb::MissingBatchHomeError)
   end
 
   it 'should abandon ship with an invalid $BATCH_HOME' do
     batch_home = File.join(@live_dir, 'uaf-fake')
-    Rhubarb.stub(:batch_home).and_return(batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(batch_home)
     expect { Rhubarb::LogRoller.new }.to raise_error(Rhubarb::InvalidBatchHomeError)
   end
 
   it 'should abandon ship with an empty $BATCH_HOME directory' do
     batch_home = File.join(@live_dir, 'uaf-tst')
-    Rhubarb.stub(:batch_home).and_return(batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(batch_home)
     expect { Rhubarb::LogRoller.new }.to raise_error(Rhubarb::EmptyBatchHomeError)
   end
 
   it 'should initialize successfully' do
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
     expect { Rhubarb::LogRoller.new }.to_not raise_error
   end
 end
@@ -36,7 +36,7 @@ describe Rhubarb::LogRoller, '#roll' do
   before(:each) do
     cleanse_live
 
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
     @logger01 = Rhubarb::Logger.new('foo')
     @logger02 = Rhubarb::Logger.new('bar')
     @message01 = 'Ridiculously Interesting Message'
@@ -57,22 +57,22 @@ describe Rhubarb::LogRoller, '#roll' do
     end
 
     it 'should roll log files out of the way' do
-      Dir.glob(File.join(@stg_batch_home, 'logs', '*.log')).should be_empty
+      expect(Dir.glob(File.join(@stg_batch_home, 'logs', '*.log'))).to be_empty
     end
 
     it 'should roll log files into their archive location' do
-      File.directory?(File.join(@stg_batch_home, 'logs', 'foo')).should be_true
-      File.directory?(File.join(@stg_batch_home, 'logs', 'bar')).should be_true
+      expect(File.directory?(File.join(@stg_batch_home, 'logs', 'foo'))).to be true
+      expect(File.directory?(File.join(@stg_batch_home, 'logs', 'bar'))).to be true
     end
 
     it 'should keep log files correct' do
       last_foo_log = Dir.glob(File.join(@stg_batch_home, 'logs', 'foo', '*.log')).last
       lines = File.readlines(last_foo_log)
-      lines.last.should match /[0-9:]{8} \(INFO\) #{@message01}/
+      expect(lines.last).to match /[0-9:]{8} \(INFO\) #{@message01}/
 
       last_bar_log = Dir.glob(File.join(@stg_batch_home, 'logs', 'bar', '*.log')).last
       lines = File.readlines(last_bar_log)
-      lines.last.should match /[0-9:]{8} \(INFO\) #{@message01}/
+      expect(lines.last).to match /[0-9:]{8} \(INFO\) #{@message01}/
     end
   end
 
@@ -111,15 +111,15 @@ describe Rhubarb::LogRoller, '#roll' do
     end
 
     foo_archives = Dir.glob(File.join(@stg_batch_home, 'logs', 'foo', '*.log'))
-    foo_archives.should include_something_like /foo_2012-08-31.log$/
-    foo_archives.should include_something_like /foo_2012-09-01.log$/
-    foo_archives.should include_something_like /foo_2012-09-02.log$/
-    foo_archives.should_not include_something_like /foo_2012-09-03.log$/
+    expect(foo_archives).to include_something_like /foo_2012-08-31.log$/
+    expect(foo_archives).to include_something_like /foo_2012-09-01.log$/
+    expect(foo_archives).to include_something_like /foo_2012-09-02.log$/
+    expect(foo_archives).not_to include_something_like /foo_2012-09-03.log$/
 
     bar_archives = Dir.glob(File.join(@stg_batch_home, 'logs', 'bar', '*.log'))
-    bar_archives.should include_something_like /bar_2012-08-31.log$/
-    bar_archives.should include_something_like /bar_2012-09-01.log$/
-    bar_archives.should include_something_like /bar_2012-09-02.log$/
-    bar_archives.should_not include_something_like /bar_2012-09-03.log$/
+    expect(bar_archives).to include_something_like /bar_2012-08-31.log$/
+    expect(bar_archives).to include_something_like /bar_2012-09-01.log$/
+    expect(bar_archives).to include_something_like /bar_2012-09-02.log$/
+    expect(bar_archives).not_to include_something_like /bar_2012-09-03.log$/
   end
 end

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -8,29 +8,29 @@ describe Rhubarb::Logger, '.new' do
   end
 
   it 'should abandon ship without $BATCH_HOME' do
-    Rhubarb.stub(:batch_home).and_return(nil)
+    allow(Rhubarb).to receive(:batch_home).and_return(nil)
     expect { Rhubarb::Logger.new('foo') }.to raise_error(Rhubarb::MissingBatchHomeError)
   end
 
   it 'should abandon ship with an invalid $BATCH_HOME' do
     batch_home = File.join(@live_dir, 'uaf-fake')
-    Rhubarb.stub(:batch_home).and_return(batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(batch_home)
     expect { Rhubarb::Logger.new('foo') }.to raise_error(Rhubarb::InvalidBatchHomeError)
   end
 
   it 'should abandon ship with an empty $BATCH_HOME directory' do
     batch_home = File.join(@live_dir, 'uaf-tst')
-    Rhubarb.stub(:batch_home).and_return(batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(batch_home)
     expect { Rhubarb::Logger.new('foo') }.to raise_error(Rhubarb::EmptyBatchHomeError)
   end
 
   it 'should abandon ship with empty arguments' do
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
     expect { Rhubarb::Logger.new }.to raise_error(ArgumentError)
   end
 
   it 'should initialize successfully with one valid argument' do
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
     expect { Rhubarb::Logger.new('foo') }.to_not raise_error
   end
 end
@@ -38,17 +38,17 @@ end
 describe Rhubarb::Logger, '#log' do
   include Helpers
 
-  before(:all) do
+  before(:each) do
     cleanse_live
 
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
     @logger = Rhubarb::Logger.new('bar')
   end
 
   it 'should log INFO successfully' do
     #log4r_logger = double('log4r_logger')
     #@logger.stub(:log4r_logger) { log4r_logger }
-    @logger.log4r_logger.should_receive(:info).with('message')
+    expect(@logger.log4r_logger).to receive(:info).with('message')
     @logger.info 'message'
   end
 end
@@ -56,38 +56,38 @@ end
 describe Rhubarb::Logger, '#h1, #h2, #h3' do
   include Helpers
 
-  before(:all) do
+  before(:each) do
     cleanse_live
 
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
     @logger = Rhubarb::Logger.new('bar')
     @message01 = 'Meh Big Fancy Header'
   end
 
   it "should log H1's successfully" do
     message = 'Big Fancy Header'
-    @logger.log4r_logger.should_receive(:info).with("# #{message}")
+    expect(@logger.log4r_logger).to receive(:info).with("# #{message}")
     @logger.h1(message)
   end
 
   it "should log H2's successfully" do
     message = 'Biggish Fancy Header'
-    @logger.log4r_logger.should_receive(:info).with("## #{message}")
+    expect(@logger.log4r_logger).to receive(:info).with("## #{message}")
     @logger.h2(message)
   end
 
   it "should log H3's successfully" do
-    @logger.log4r_logger.should_receive(:info).with("### #{@message01}")
+    expect(@logger.log4r_logger).to receive(:info).with("### #{@message01}")
     @logger.h3(@message01)
   end
 
   it "should log H4's successfully" do
-    @logger.log4r_logger.should_receive(:info).with("#### #{@message01}")
+    expect(@logger.log4r_logger).to receive(:info).with("#### #{@message01}")
     @logger.h4(@message01)
   end
 
   it "should log H5's successfully" do
-    @logger.log4r_logger.should_receive(:info).with("##### #{@message01}")
+    expect(@logger.log4r_logger).to receive(:info).with("##### #{@message01}")
     @logger.h5(@message01)
   end
 end
@@ -95,10 +95,10 @@ end
 describe Rhubarb::Logger, '#log4r_logger' do
   include Helpers
 
-  before(:all) do
+  before(:each) do
     cleanse_live
 
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
     @logger = Rhubarb::Logger.new('foo')
     @message01 = 'texty text text'
   end
@@ -106,41 +106,41 @@ describe Rhubarb::Logger, '#log4r_logger' do
   it "should actually log successfully" do
     @logger.info(@message01)
     lines = File.readlines(@logger.job_stream_file)
-    lines.last.should match /[0-9:]{8} \(INFO\) #{@message01}/
+    expect(lines.last).to match /[0-9:]{8} \(INFO\) #{@message01}/
   end
 
   it "should actually log successfully" do
     @logger.warn(@message01)
     lines = File.readlines(@logger.job_stream_file)
-    lines.last.should match /[0-9:]{8} \(WARN\) #{@message01}/
+    expect(lines.last).to match /[0-9:]{8} \(WARN\) #{@message01}/
   end
 
   it "should actually log successfully" do
     @logger.error(@message01)
     lines = File.readlines(@logger.job_stream_file)
-    lines.last.should match /[0-9:]{8} \(ERROR\) #{@message01}/
+    expect(lines.last).to match /[0-9:]{8} \(ERROR\) #{@message01}/
   end
 end
 
 describe Rhubarb::Logger, '#stamp' do
   include Helpers
 
-  before(:all) do
+  before(:each) do
     cleanse_live
 
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
     @logger = Rhubarb::Logger.new('foo')
     @message01 = 'texty text text'
   end
 
   it "should stamp successfully" do
-    @logger.log4r_logger.should_receive(:info).with(@message01)
+    expect(@logger.log4r_logger).to receive(:info).with(@message01)
     @logger.stamp(@message01)
   end
 
   it "should actually stamp successfully" do
     @logger.stamp(@message01)
     lines = File.readlines(@logger.job_stream_file)
-    lines.last.should match /\w+, \d+ \w+ \d{4} [0-9:]{8} [\-0-9]+ #{@message01}/
+    expect(lines.last).to match /\w+, \d+ \w+ \d{4} [0-9:]{8} [\-0-9]+ #{@message01}/
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ module Matchers
       "expected #{@enumerable} to include something that matched /#{@expected_match}/, but no such luck"
     end
 
-    def negative_failure_message
+    def failure_message_when_negated
       "expected #{@enumerable} to not include anything that matched /#{@expected_match}/, but found '#{@examples.first}'"
     end
   end

--- a/spec/sql_spec.rb
+++ b/spec/sql_spec.rb
@@ -8,32 +8,32 @@ describe Rhubarb::SQL, '.new' do
   end
 
   it 'should abandon ship without $BATCH_HOME' do
-    Rhubarb.stub(:batch_home).and_return(nil)
+    allow(Rhubarb).to receive(:batch_home).and_return(nil)
     expect { Rhubarb::SQL.new('foo.sql') }.to raise_error(Rhubarb::MissingBatchHomeError)
   end
 
   it 'should abandon ship with an invalid $BATCH_HOME' do
     batch_home = File.join(@live_dir, 'uaf-fake')
-    Rhubarb.stub(:batch_home).and_return(batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(batch_home)
     expect { Rhubarb::SQL.new('foo.sql') }.to raise_error(Rhubarb::InvalidBatchHomeError)
   end
 
   it 'should abandon ship with an empty $BATCH_HOME directory' do
     batch_home = File.join(@live_dir, 'uaf-tst')
-    Rhubarb.stub(:batch_home).and_return(batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(batch_home)
     expect { Rhubarb::SQL.new('foo.sql') }.to raise_error(Rhubarb::EmptyBatchHomeError)
   end
 
   it 'should abandon ship without a sql directory' do
     batch_home = File.join(@live_dir, 'uaf-cfg')
-    Rhubarb.stub(:batch_home).and_return(batch_home)
+    allow(Rhubarb).to receive(:batch_home).and_return(batch_home)
     expect { Rhubarb::SQL.new('foo.sql') }.to raise_error(Rhubarb::SQL::MissingSQLDirectoryError)
   end
 
   it 'should initialize successfully' do
     pending
-    Rhubarb.stub(:batch_home).and_return(@stg_batch_home)
-    Rhubarb::SQL.stub(:sql_home).and_return()
+    allow(Rhubarb).to receive(:batch_home).and_return(@stg_batch_home)
+    allow(Rhubarb::SQL).to receive(:sql_home).and_return()
     expect { Rhubarb::SQL.new('foo.sql') }.to_not raise_error
   end
 end


### PR DESCRIPTION
..., change scope for method stub to be 'each' instead of 'all', and rename 'negative_failure_message' method to 'failure_message_when_negated' method in custom Matchers. All changes stem from deprecation warnings and test failures.

Also update README.md to reflect Ruby version this was locally tested against.
