### PR TITLE
KATTS-3844 update status timeout in driver from 150 to 210 minutes

### DIFF
--- a/lib/rhubarb/driver.rb
+++ b/lib/rhubarb/driver.rb
@@ -27,7 +27,7 @@ class Rhubarb::Driver
       raise Rhubarb::MissingControlDirectoryError
     end
 
-    @status_timeout = 150.minutes
+    @status_timeout = 210.minutes
     @status_sleep = 5.seconds
 
     debug "batch_home:        #{Rhubarb.batch_home.inspect}"


### PR DESCRIPTION
Updated timeout. Created branch off of master (created first off of development, then deleted it).
